### PR TITLE
MAINT: Reorganize readers into IO.

### DIFF
--- a/pydisdrometer/__init__.py
+++ b/pydisdrometer/__init__.py
@@ -1,14 +1,16 @@
-from .ParsivelReader import read_parsivel
-from .ParsivelNasaGVReader import read_parsivel_nasa_gv
-from .JWDReader import read_jwd
+from .io.ParsivelReader import read_parsivel
+from .io.ParsivelNasaGVReader import read_parsivel_nasa_gv
+from .io.JWDReader import read_jwd
+from .io.Image2DReader import read_ucsc_netcdf, read_noaa_aoml_netcdf
+
 from .aux_readers.GPMApuWallopsRawReader import read_gpm_nasa_apu_raw_wallops
 from .aux_readers.NASA_2DVD_reader import read_2dvd_sav_nasa_gv
 from .aux_readers.NASA_2DVD_reader import read_2dvd_dsd_nasa_gv
 from .aux_readers.ARM_APU_reader import read_parsivel_arm_netcdf
-from .plot.plot import plot_dsd
 from .aux_readers.read_2ds import read_2ds
 from .aux_readers.read_hvps import read_hvps
-from .io.Image2DReader import read_ucsc_netcdf, read_noaa_aoml_netcdf
+
+from .plot.plot import plot_dsd
 
 from . import partition
 from . import utility

--- a/pydisdrometer/io/JWDReader.py
+++ b/pydisdrometer/io/JWDReader.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 import numpy as np
-from DropSizeDistribution import DropSizeDistribution
+from ..DropSizeDistribution import DropSizeDistribution
 #from .common import _get_epoch_time
 
 

--- a/pydisdrometer/io/ParsivelNasaGVReader.py
+++ b/pydisdrometer/io/ParsivelNasaGVReader.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 import numpy as np
-import numpy.ma as ma
-from DropSizeDistribution import DropSizeDistribution
+from ..DropSizeDistribution import DropSizeDistribution
 
 import itertools
 import scipy.optimize
@@ -11,7 +10,7 @@ import datetime
 import time
 from netCDF4 import num2date, date2num
 
-from .io import common
+from . import common
 
 
 def read_parsivel_nasa_gv(filename, campaign='ifloods', skip_header=None):

--- a/pydisdrometer/io/ParsivelReader.py
+++ b/pydisdrometer/io/ParsivelReader.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 import numpy as np
-import numpy.ma as ma
-from DropSizeDistribution import DropSizeDistribution
+from ..DropSizeDistribution import DropSizeDistribution
 
 
 def read_parsivel(filename):


### PR DESCRIPTION
Moving readers into the ```io``` folder.

Question: Should we move the aux readers into the folder as well?