### PR TITLE
Metadata internal structure for derived fields

### DIFF
--- a/description.txt
+++ b/description.txt
@@ -1,3 +1,3 @@
 PyDisdrometer is a Python package to process disdrometer files. It currently is capable of reading several different types of disdrometers and calculating both important moment parameters, as well as radar derived parameters. It currently supports OTT Parsivel disdrometers and Joss Waldvogel Disdrometers. It is currently in alpha so functionality is limited but being expanded quickly.
 
-Author: Joseph C. Hardin
+Author: Joseph C. Hardin, Nick Guy

--- a/pydisdrometer/tests/testConfiguration.py
+++ b/pydisdrometer/tests/testConfiguration.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+
+import numpy as np
+import unittest
+from ..utility import configuration
+
+from .. import DropSizeDistribution
+
+class testConfiguration(unittest.TestCase):
+    ''' Unit tests for Configuration Class'''
+
+    def setUp(self):
+        self.config = configuration.Configuration()
+
+    def test_config_loads_and_has_keys(self):
+        self.assertIsNotNone(self.config)
+        self.assertTrue(len(self.config.metadata.keys()) > 0 )

--- a/pydisdrometer/utility/configuration.py
+++ b/pydisdrometer/utility/configuration.py
@@ -1,0 +1,32 @@
+import json
+from copy import copy
+import os
+
+
+
+class Configuration(object):
+    ''' Class to store PyDisdrometer configuration options
+
+    Attributes:
+    -----------
+
+    '''
+    config_dir = os.path.dirname(os.path.abspath(__file__))
+    metadata_config_file = os.path.join(config_dir, 'metadata.json')
+
+    def __init__(self):
+        self.metadata = self.load_metadata_config()
+
+    def load_metadata_config(self):
+        ''' Load the metadata configuration file and return the dictionary'''
+        return json.load(open(self.metadata_config_file))
+
+
+    def fill_in_metadata(self, field, data):
+        metadata = self.metadata[field].copy()
+        metadata['data'] = copy(data)
+        return metadata
+
+
+
+

--- a/pydisdrometer/utility/metadata.json
+++ b/pydisdrometer/utility/metadata.json
@@ -1,0 +1,88 @@
+{
+    "D0":
+    {
+        "standard_name": "median_drop_diameter",
+        "units": "mm",
+        "long_name": "Median Drop Diameter"
+    },
+    "Dmax":
+    {
+        "standard_name": "maximum_drop_diameter",
+        "units": "mm",
+        "long_name" :"Maximum Drop Diameter"
+    },
+    "Dm":
+    {
+        "standard_name": "mean_drop_diameter",
+        "units": "mm",
+        "long_name" :"Mean Drop Diameter"
+    },
+    "Nw":
+    {
+        "standard_name": "normalized_intercept_parameter",
+        "units": "?",
+        "long_name" :"Normalized Intercept Parameter of a Normalized Gaussian Distribution"
+    },
+    "Nt":
+    {
+        "standard_name": "total_droplet_concentration",
+        "units": "m^-1",
+        "long_name" :"Total Droplet Concentration"
+    },
+    "N0":
+    {
+        "standard_name": "intercept_parameter",
+        "units": "?",
+        "long_name" :"Intercept Parameter of Modeled Drop Size Distribution"
+    },
+    "W":
+    {
+        "standard_name": "water_mass",
+        "units": "g/m^3",
+        "long_name" :"Water Mass of Drop Size Distribution"
+    },
+    "mu":
+    {
+        "standard_name": "shape_parameter",
+        "units": " ",
+        "long_name" :"Shape Parameter of Modeled Drop Size Distribution"
+    },
+    "rain_rate":
+    {
+        "standard_name": "rain_rate",
+        "units": "mm/h",
+        "long_name" :"Instantaneous Rainfall Rate of Water Flux"
+    },
+    "Zh":
+    {
+        "standard_name": "horizontal_reflectivity",
+        "units": "dBZ",
+        "long_name" :"Estimated Horizontal Radar Reflectivity from Drop Size Distribution"
+    },
+    "Zdr":
+    {
+        "standard_name": "differential_reflectivity",
+        "units": "dBZ",
+        "long_name" :"Estimated Differential Radar Reflectivity (H, V) from Drop Size Distribution"
+    },
+    "Kdp":
+    {
+        "standard_name": "specific_differential_phase",
+        "units": "deg",
+        "long_name" :"Specific Differential Phase from Drop Size Distribution"
+    },
+    "Ai":
+    {
+        "standard_name": "specific_attenuation",
+        "units": "dB/km",
+        "long_name": "Specific Attenuation"
+    },
+    "Adr":
+    {
+        "standard_name": "specific_differential_attenuation",
+        "units": "dB/km",
+        "long_name": "Specific Differential Attenuation"
+    }
+}
+
+


### PR DESCRIPTION
This PR is a result of a code sprint between Nick and myself that adds metadata to the internally derived fields. The actual metadata comes from a metadata.json in the utility that will need later review to make sure everything is consistent and matches CF and CF/Radial as much as possible, but for now this is functional and ready to be merged. This will be the last change I believe before we merge our dev branch back into master