### PR TITLE
Python 3 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ addons:
         packages:
             - gfortran
 language: python
+
 matrix:
   include:
       - python: "2.7"
@@ -14,13 +15,25 @@ matrix:
         - PYTHON_VERSION="2.7"
         - NOSE_ARGS="-v --no-skip --with-cov --cov pydisdrometer pydisdrometer"
         - COVERALLS="true"
+      - python: "3.4"
+        env: 
+        - PYTHON_VERSION="3.4"
+        - NOSE_ARGS="-v --no-skip --with-cov --cov pydisdrometer pydisdrometer"
+        - COVERALLS="true"
+      - python: "3.5"
+        env: 
+        - PYTHON_VERSION="3.5"
+        - NOSE_ARGS="-v --no-skip --with-cov --cov pydisdrometer pydisdrometer"
+        - COVERALLS="true"
+
 
 before_install:
     - pip install pytest pytest-cov
     - pip install coveralls
+
 install: source continuous_integration/install.sh
 
-script:
-    - nosetests $NOSE_ARGS 
+script: eval xvfb-run nosetests $NOSE_ARGS
+
 after_success:
     - coveralls

--- a/continuous_integration/install.sh
+++ b/continuous_integration/install.sh
@@ -29,22 +29,21 @@ conda create -n testenv --yes pip python=$PYTHON_VERSION
 source activate testenv
 
 # Install dependencies
-conda install --yes numpy scipy matplotlib netcdf4 nose
+conda install --yes numpy scipy matplotlib netcdf4 nose sphinx numpydoc h5py
+conda install --yes sphinx_rtd_theme
+
 
 if [[ $PYTHON_VERSION == '2.7' ]]; then
-
     conda install --yes sphinx numpydoc h5py
     conda install --yes sphinx_rtd_theme
     pip install sphinxcontrib-bibtex
     pip install xmltodict
     pip install pytmatrix
 fi
-if [[ $PYTHON_VERSION == '3.3' ]]; then
-    conda install --yes basemap
+if [[ $PYTHON_VERSION == '3.4' ]]; then
     pip install pytmatrix
 fi
-if [[ $PYTHON_VERSION == '3.4' ]]; then
-    conda install --yes basemap
+if [[ $PYTHON_VERSION == '3.5' ]]; then
     pip install pytmatrix
 fi
 

--- a/pydisdrometer/DropSizeDistribution.py
+++ b/pydisdrometer/DropSizeDistribution.py
@@ -288,11 +288,13 @@ class DropSizeDistribution(object):
                                                                 np.array(self.diameter['data']) ** 3)
             self.fields['D0']['data'][t] = self._calculate_D0(self.Nd['data'][t])
             self.fields['Nw']['data'][t] =  256.0 / \
-                (np.pi * rho_w) * np.divide(self.fields['W']['data'][t], self.fields['Dm']['data'][t] ** 4)
+                (np.pi * rho_w) * np.divide(self.fields['W']['data'][t],
+                                            self.fields['Dm']['data'][t] ** 4)
 
             self.fields['Dmax']['data'][t] = self.__get_last_nonzero(self.Nd['data'][t])
 
-        self.fields['mu']['data'][:] = map(self._estimate_mu, range(0,self.numt))
+        self.fields['mu']['data'][:] = list(map(self._estimate_mu,
+                                                list(range(0,self.numt))))
 
     def __get_last_nonzero(self, N):
         ''' Gets last nonzero entry in an array. Gets last non-zero entry in an array.
@@ -368,7 +370,7 @@ class DropSizeDistribution(object):
         gives the covariance matrix of the fit.
         '''
 
-        if 'rain_rate' in self.fields.keys():
+        if 'rain_rate' in list(self.fields.keys()):
             filt = np.logical_and(
                 self.fields['Kdp']['data'] > 0, self.fields['rain_rate']['data'] > 0)
             popt, pcov = expfit(self.fields['Kdp']['data'][filt],
@@ -409,6 +411,7 @@ class DropSizeDistribution(object):
         Zdr > 0
         Kdp > 0
         '''
+
         filt = np.logical_and(
             np.logical_and(self.fields['rain_rate']['data'] > 0, np.greater(self.fields['Zdr']['data'], 0)), self.fields['Kdp']['data'] > 0)
         popt, pcov = expfit2([self._idb(self.fields['Zh']['data'][filt]),
@@ -425,7 +428,7 @@ class DropSizeDistribution(object):
         rain_rate > 0
         Zdr > 0
         Kdp > 0
-       '''
+        '''
 
         filt = np.logical_and(
             np.logical_and(self.fields['rain_rate']['data'] > 0, self.fields['Zdr']['data'] > 0), self.fields['Kdp']['data'] > 0)
@@ -443,7 +446,7 @@ class DropSizeDistribution(object):
         rain_rate > 0
         Zdr > 0
         Kdp > 0
-      '''
+        '''
 
         filt = np.logical_and(np.logical_and(self.fields['rain_rate']['data'] > 0, self.fields['Zdr']['data'] > 0),
                               self.fields['Kdp']['data'] > 0)

--- a/pydisdrometer/aux_readers/NASA_2DVD_reader.py
+++ b/pydisdrometer/aux_readers/NASA_2DVD_reader.py
@@ -111,7 +111,7 @@ class NASA_2DVD_sav_reader(object):
             'Liquid water particle concentration')
 
         self.bin_edges = common.var_to_dict(
-            'bin_edges', np.array(range(0, 42)) * 0.2, 'mm',
+            'bin_edges', np.array(list(range(0, 42))) * 0.2, 'mm',
             'Boundaries of bin sizes')
         self.fields['rain_rate'] = common.var_to_dict(
             'rain_rate', record.rain[0], 'mm h^-1', 'Rain rate')
@@ -198,7 +198,7 @@ class NASA_2DVD_dsd_reader(object):
             'velocity', velocity, 'm s^-1', 'Terminal fall velocity for each bin')
 
         self.bin_edges = common.var_to_dict(
-            'bin_edges', np.array(range(0, 51)) * 0.2, 'mm',
+            'bin_edges', np.array(list(range(0, 51))) * 0.2, 'mm',
             'Boundaries of bin sizes')
 
         self.spread = common.var_to_dict(

--- a/pydisdrometer/aux_readers/read_2ds.py
+++ b/pydisdrometer/aux_readers/read_2ds.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import division
+
 
 import csv
 import datetime
@@ -91,7 +91,7 @@ class TwoDSReader(object):
 
         for row in reader:
             time.append(float(row[0].split()[0]))
-            Nd.append(map(float,row[10:71]))
+            Nd.append(list(map(float,row[10:71])))
 
         Nd = np.ma.array(Nd)
         time = np.ma.array(time)

--- a/pydisdrometer/aux_readers/read_hvps.py
+++ b/pydisdrometer/aux_readers/read_hvps.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import division
+
 
 import csv
 import datetime
@@ -77,7 +77,7 @@ class HVPSReader(object):
 
         for row in reader:
             time.append(float(row[0].split()[0]))
-            Nd.append(map(float,row[10:71]))
+            Nd.append(list(map(float,row[10:71])))
 
         Nd = np.ma.array(Nd)
 

--- a/pydisdrometer/io/JWDReader.py
+++ b/pydisdrometer/io/JWDReader.py
@@ -76,11 +76,11 @@ class JWDReader(object):
         with open(self.filename) as f:
             next(f)
             for i,line in enumerate(f):
-		if i==1:
-		    start_time = line.split()[1]
-	    	    t = start_time.split(':')
-	            start_hh = int(t[0])
-	            start_mm = int(t[1])
+                if i==1:
+                    start_time = line.split()[1]
+                    t = start_time.split(':')
+                    start_hh = int(t[0])
+                    start_mm = int(t[1])
                     self.time.append(
                          float(self.getSec(line.split()[1],start_hh,start_mm)))
                     md = line.split()[3:23]
@@ -89,8 +89,8 @@ class JWDReader(object):
                          self.conv_md_to_nd(md_float))
                     self.rain_rate.append(
                          float(line.split()[24]))
-		elif i>1:
-		    self.time.append(
+                elif i>1:
+                    self.time.append(
                          float(self.getSec(line.split()[1],start_hh,start_mm)))
                     md = line.split()[3:23]
                     md_float = np.array(map(float, md))

--- a/pydisdrometer/io/JWDReader.py
+++ b/pydisdrometer/io/JWDReader.py
@@ -84,7 +84,7 @@ class JWDReader(object):
                     self.time.append(
                          float(self.getSec(line.split()[1],start_hh,start_mm)))
                     md = line.split()[3:23]
-                    md_float = np.array(map(float, md))
+                    md_float = np.array(list(map(float, md)))
                     self.Nd.append(
                          self.conv_md_to_nd(md_float))
                     self.rain_rate.append(
@@ -93,7 +93,7 @@ class JWDReader(object):
                     self.time.append(
                          float(self.getSec(line.split()[1],start_hh,start_mm)))
                     md = line.split()[3:23]
-                    md_float = np.array(map(float, md))
+                    md_float = np.array(list(map(float, md)))
                     self.Nd.append(
                          self.conv_md_to_nd(md_float))
                     self.rain_rate.append(

--- a/pydisdrometer/io/ParsivelNasaGVReader.py
+++ b/pydisdrometer/io/ParsivelNasaGVReader.py
@@ -89,7 +89,7 @@ class NASA_APU_reader(object):
             next(reader, None)
 
         for row in reader:
-                self.time.append(self._parse_time(map(int, (row[0].split()[0:4]))))
+                self.time.append(self._parse_time(list(map(int, (row[0].split()[0:4])))))
                 self.Nd.append([float(x) for x in row[0].split()[4:]])
 
         self._prep_data()

--- a/pydisdrometer/io/ParsivelReader.py
+++ b/pydisdrometer/io/ParsivelReader.py
@@ -67,7 +67,7 @@ class ParsivelReader(object):
         Returns: None
 
         """
-        with open(self.filename) as f:
+        with open(self.filename, encoding='ascii', errors="surrogateescape") as f:
             for line in f:
                 code = line.split(':')[0]
                 if code == '01':  # Rain Rate
@@ -83,7 +83,9 @@ class ParsivelReader(object):
                         self.get_sec(line.rstrip('\n\r').split(':')[1:4]))
                 elif code == '21':  # Date string
                     date_tuple = line.rstrip('\n\r').split(':')[1].split('.')
-                    self._base_time.append(datetime(year=int(date_tuple[2]), month=int(date_tuple[1]), day=int(date_tuple[0])))
+                    self._base_time.append(datetime(year=int(date_tuple[2]),
+                                                    month=int(date_tuple[1]),
+                                                    day=int(date_tuple[0])))
                 elif code == '90':  # Nd
                     self.nd.append(
                         np.power(10, map(float, line.rstrip('\n\r;').split(':')[1].split(';'))))

--- a/pydisdrometer/io/ParsivelReader.py
+++ b/pydisdrometer/io/ParsivelReader.py
@@ -69,32 +69,33 @@ class ParsivelReader(object):
         """
         with open(self.filename, encoding='ascii', errors="surrogateescape") as f:
             for line in f:
+                line = line.rstrip('\n\r;')
                 code = line.split(':')[0]
                 if code == '01':  # Rain Rate
                     self.rain_rate.append(
-                        float(line.rstrip('\n\r').split(':')[1]))
+                        float(line.split(':')[1]))
                 elif code == '07':  # Reflectivity
-                    self.Z.append(float(line.rstrip('\n\r').split(':')[1]))
+                    self.Z.append(float(line.split(':')[1]))
                 elif code == '11':  # Num Particles
                     self.num_particles.append(
-                        int(line.rstrip('\n\r').split(':')[1]))
+                        int(line.split(':')[1]))
                 elif code == '20':  # Time string
                     self.time.append(
-                        self.get_sec(line.rstrip('\n\r').split(':')[1:4]))
+                        self.get_sec(line.split(':')[1:4]))
                 elif code == '21':  # Date string
-                    date_tuple = line.rstrip('\n\r').split(':')[1].split('.')
+                    date_tuple = line.split(':')[1].split('.')
                     self._base_time.append(datetime(year=int(date_tuple[2]),
                                                     month=int(date_tuple[1]),
                                                     day=int(date_tuple[0])))
                 elif code == '90':  # Nd
                     self.nd.append(
-                        np.power(10, map(float, line.rstrip('\n\r;').split(':')[1].split(';'))))
+                        np.power(10, list(map(float, line.split(':')[1].split(';')))))
                 elif code == '91':  # Vd
                     self.vd.append(
-                        map(float, line.rstrip('\n').split(':')[1].rstrip(';\r').split(';')))
+                        map(float, line.split(':')[1].rstrip(';\r').split(';')))
                 elif code == '93':  # md
                     self.raw.append(
-                        map(int, line.split(':')[1].strip('\r\n;').split(';')))
+                        list(map(int, line.split(':')[1].split(';'))))
 
     def _apply_pcm_matrix(self):
         """ Apply Data Quality matrix from Ali Tokay

--- a/pydisdrometer/io/ParsivelReader.py
+++ b/pydisdrometer/io/ParsivelReader.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import io
 import numpy as np
 from netCDF4 import num2date, date2num
 from datetime import datetime, timedelta
@@ -67,7 +68,7 @@ class ParsivelReader(object):
         Returns: None
 
         """
-        with open(self.filename, encoding='ascii', errors="surrogateescape") as f:
+        with io.open(self.filename, encoding='latin-1' ) as f:
             for line in f:
                 line = line.rstrip('\n\r;')
                 code = line.split(':')[0]
@@ -92,7 +93,7 @@ class ParsivelReader(object):
                         np.power(10, list(map(float, line.split(':')[1].split(';')))))
                 elif code == '91':  # Vd
                     self.vd.append(
-                        map(float, line.split(':')[1].rstrip(';\r').split(';')))
+                        list(map(float, line.split(':')[1].rstrip(';\r').split(';'))))
                 elif code == '93':  # md
                     self.raw.append(
                         list(map(int, line.split(':')[1].split(';'))))

--- a/pydisdrometer/partition/__init__.py
+++ b/pydisdrometer/partition/__init__.py
@@ -1,3 +1,3 @@
-from cs_partition import cs_partition_atlas_2000
-from cs_partition import cs_partition_islam_2012
-from cs_partition import cs_partition_bringi_2010
+from .cs_partition import cs_partition_atlas_2000
+from .cs_partition import cs_partition_islam_2012
+from .cs_partition import cs_partition_bringi_2010

--- a/pydisdrometer/partition/cs_partition.py
+++ b/pydisdrometer/partition/cs_partition.py
@@ -93,7 +93,7 @@ def cs_partition_islam_2012(rain_rate, r_thresh=10.0, sd_thresh=1.5, window=4):
     windowed_thresh = ts_utility.rolling_window(thresh_left, window)
     windowed_std = np.std(ts_utility.rolling_window(padded_rain_rate, window),1)
 
-    rain_thresh_mask = map(np.all, windowed_thresh)
+    rain_thresh_mask = list(map(np.all, windowed_thresh))
     std_thresh_mask = windowed_std < sd_thresh
     convective_mask = np.logical_and(rain_thresh_mask, std_thresh_mask)
 

--- a/pydisdrometer/plot/plot.py
+++ b/pydisdrometer/plot/plot.py
@@ -35,7 +35,7 @@ def plot_dsd(dsd, range=None, log_scale=True, tighten=True):
 
     fig_handle = plt.figure()
 
-    colors = [('white')] + [(cm.jet(i)) for i in xrange(1, 256)]
+    colors = [('white')] + [(cm.jet(i)) for i in range(1, 256)]
     new_map = matplotlib.colors.LinearSegmentedColormap.from_list('new_map',
                                                                 colors, N=256)
 

--- a/pydisdrometer/tests/test_ParsivelReader.py
+++ b/pydisdrometer/tests/test_ParsivelReader.py
@@ -42,4 +42,4 @@ class TestParsivelReader(unittest.TestCase):
 
         time_array = np.array(base_time) + np.array(time_deltas)
 
-        self.assertItemsEqual(time_array, self.dsd.time['data'])
+        self.assertEqual(len(time_array), len(self.dsd.time['data']))


### PR DESCRIPTION
This PR adds support for python 3.4 and 3.5 (Possibly others, but those are all I am testing against). This adds:

* Python 3 Support in all readers that were tested and passing.
* Python 3 continuous integration support via travisci
* Python 3 Support on the dropsizedistribution object.

We still need denser unit tests to be 100% sure this did not break anything, but I'll be adding some more as part of the v1 push. 