### PR TITLE
Installing pytmatrix from github repo to avoid old pip version

### DIFF
--- a/continuous_integration/install.sh
+++ b/continuous_integration/install.sh
@@ -33,6 +33,7 @@ conda install --yes numpy scipy matplotlib netcdf4 nose sphinx numpydoc hdf4=4.2
 conda install --yes sphinx_rtd_theme
 
 
+pip install git+https://github.com/jleinonen/pytmatrix.git
 if [[ $PYTHON_VERSION == '2.7' ]]; then
     conda install --yes sphinx numpydoc hdf4=4.2.12
     conda install --yes sphinx_rtd_theme


### PR DESCRIPTION
This PR installs PyTMatrix directly from github for the testrunner in travis. This helps avoid the current issue with an old version of pytmatrix in PyPI. 